### PR TITLE
Turbo refreshes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 !/app/assets/builds/.keep
 
 *.swp
+.overmind.env

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # allow_browser versions: :modern
 end

--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -1,0 +1,4 @@
+class ExperimentsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/turbo_actions/inboxes_controller.rb
+++ b/app/controllers/turbo_actions/inboxes_controller.rb
@@ -1,0 +1,14 @@
+class TurboActions::InboxesController < ApplicationController
+  def index
+    @inboxes = Inbox.order(:name)
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/controllers/turbo_actions/inboxes_controller.rb
+++ b/app/controllers/turbo_actions/inboxes_controller.rb
@@ -5,6 +5,8 @@ class TurboActions::InboxesController < ApplicationController
 
   def show
     @inbox = Inbox.find(params[:id])
+    @messages_scope = params[:messages_scope].to_s == "read" ? :read : :unread
+    @messages = @inbox.messages.ordered.public_send(@messages_scope)
   end
 
   def edit

--- a/app/controllers/turbo_actions/inboxes_controller.rb
+++ b/app/controllers/turbo_actions/inboxes_controller.rb
@@ -8,10 +8,4 @@ class TurboActions::InboxesController < ApplicationController
     @messages_scope = params[:messages_scope].to_s == "read" ? :read : :unread
     @messages = @inbox.messages.ordered.public_send(@messages_scope)
   end
-
-  def edit
-  end
-
-  def update
-  end
 end

--- a/app/controllers/turbo_actions/inboxes_controller.rb
+++ b/app/controllers/turbo_actions/inboxes_controller.rb
@@ -4,6 +4,7 @@ class TurboActions::InboxesController < ApplicationController
   end
 
   def show
+    @inbox = Inbox.find(params[:id])
   end
 
   def edit

--- a/app/controllers/turbo_actions/messages_controller.rb
+++ b/app/controllers/turbo_actions/messages_controller.rb
@@ -8,11 +8,11 @@ class TurboActions::MessagesController < ApplicationController
       format.html do
         if @message.errors.empty?
           flash.notice = "Message #{@message.id} updated!"
-          redirect_to [:turbo_actions, @message.inbox]
         else
           flash.alert = "Message #{@message.id} could not be updated: #{@message.errors.full_messages.to_sentence}"
-          render "turbo_actions/inbox"
         end
+
+        redirect_to [:turbo_actions, @message.inbox, turbo_enabled: false]
       end
 
       format.turbo_stream do

--- a/app/controllers/turbo_actions/messages_controller.rb
+++ b/app/controllers/turbo_actions/messages_controller.rb
@@ -17,7 +17,11 @@ class TurboActions::MessagesController < ApplicationController
 
       format.turbo_stream do
         @inbox.broadcast_update_to(@inbox, partial: "turbo_actions/inboxes/summary")
-        render turbo_stream: turbo_stream.replace(@message)
+
+        render turbo_stream: [
+          turbo_stream.replace([@inbox, :unread_messages], partial: "turbo_actions/inboxes/messages", locals: { inbox: @inbox, messages: @inbox.messages.unread, scope: :unread }),
+          turbo_stream.replace([@inbox, :read_messages], partial: "turbo_actions/inboxes/messages", locals: { inbox: @inbox, messages: @inbox.messages.read, scope: :read })
+        ]
       end
     end
   end

--- a/app/controllers/turbo_actions/messages_controller.rb
+++ b/app/controllers/turbo_actions/messages_controller.rb
@@ -1,0 +1,30 @@
+class TurboActions::MessagesController < ApplicationController
+  def update
+    @message = Message.find(params[:id])
+    @inbox = @message.inbox
+    @message.update(permitted_params)
+
+    respond_to do |format|
+      format.html do
+        if @message.errors.empty?
+          flash.notice = "Message #{@message.id} updated!"
+          redirect_to [:turbo_actions, @message.inbox]
+        else
+          flash.alert = "Message #{@message.id} could not be updated: #{@message.errors.full_messages.to_sentence}"
+          render "turbo_actions/inbox"
+        end
+      end
+
+      format.turbo_stream do
+        @inbox.broadcast_update_to(@inbox, partial: "turbo_actions/inboxes/summary")
+        render turbo_stream: turbo_stream.replace(@message)
+      end
+    end
+  end
+
+private
+
+  def permitted_params
+    params.require(:message).permit(:read)
+  end
+end

--- a/app/controllers/turbo_refreshes/inboxes_controller.rb
+++ b/app/controllers/turbo_refreshes/inboxes_controller.rb
@@ -8,10 +8,4 @@ class TurboRefreshes::InboxesController < ApplicationController
     @messages_scope = params[:messages_scope].to_s == "read" ? :read : :unread
     @messages = @inbox.messages.ordered.public_send(@messages_scope)
   end
-
-  def edit
-  end
-
-  def update
-  end
 end

--- a/app/controllers/turbo_refreshes/inboxes_controller.rb
+++ b/app/controllers/turbo_refreshes/inboxes_controller.rb
@@ -1,0 +1,17 @@
+class TurboRefreshes::InboxesController < ApplicationController
+  def index
+    @inboxes = Inbox.order(:name)
+  end
+
+  def show
+    @inbox = Inbox.find(params[:id])
+    @messages_scope = params[:messages_scope].to_s == "read" ? :read : :unread
+    @messages = @inbox.messages.ordered.public_send(@messages_scope)
+  end
+
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/controllers/turbo_refreshes/messages_controller.rb
+++ b/app/controllers/turbo_refreshes/messages_controller.rb
@@ -1,0 +1,31 @@
+class TurboRefreshes::MessagesController < ApplicationController
+  def update
+    @message = Message.find(params[:id])
+    @inbox = @message.inbox
+    @message.update(permitted_params)
+
+    respond_to do |format|
+      format.html do
+        if @message.errors.empty?
+          flash.notice = "Message #{@message.id} updated!"
+        else
+          flash.alert = "Message #{@message.id} could not be updated: #{@message.errors.full_messages.to_sentence}"
+        end
+
+        redirect_to [:turbo_refreshes, @message.inbox]
+      end
+
+      format.turbo_stream do
+        @inbox.broadcast_refresh
+        render turbo_stream: turbo_stream.action(:refresh, "")
+      end
+    end
+  end
+
+private
+
+  def permitted_params
+    params.require(:message).permit(:read)
+  end
+end
+

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -1,0 +1,2 @@
+class Inbox < ApplicationRecord
+end

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -1,2 +1,5 @@
 class Inbox < ApplicationRecord
+
+  has_many :messages
+
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ApplicationRecord
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,8 @@
 class Message < ApplicationRecord
   belongs_to :inbox
 
-  scope :ordered, -> { order(Arel.sql("read_at DESC NULLS FIRST, id ASC")) }
+  scope :ordered, -> { order(:id) }
+  scope :read, -> { where.not(read_at: nil) }
   scope :unread, -> { where(read_at: nil) }
 
   def read=(read)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,5 @@
 class Message < ApplicationRecord
+  belongs_to :inbox
+
+  scope :unread, -> { where(read_at: nil) }
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,10 @@
 class Message < ApplicationRecord
   belongs_to :inbox
 
+  scope :ordered, -> { order(Arel.sql("read_at DESC NULLS FIRST, id ASC")) }
   scope :unread, -> { where(read_at: nil) }
+
+  def read=(read)
+    self.read_at = ActiveRecord::Type::Boolean.new.cast(read) ? Time.current : nil
+  end
 end

--- a/app/views/experiments/index.html.erb
+++ b/app/views/experiments/index.html.erb
@@ -1,0 +1,17 @@
+<h1 class="font-bold md:text-4xl mb-4">Experiments</h1>
+
+<%
+  experiments = {
+    "Inboxes with Turbo disabled"    => [:turbo_actions, :inboxes, turbo_enabled: false],
+    "Inboxes with Turbo 7 Actions"   => [:turbo_actions, :inboxes],
+    "Inboxes with Turbo 8 Refreshes" => [:turbo_refreshes, :inboxes]
+  }
+%>
+
+<ul>
+  <% experiments.each do |text, href| %>
+    <li class="mb-4">
+      <%= link_to text, href, class: "text-sky-600 hover:underline" %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,13 +3,14 @@
   <head>
     <title><%= content_for(:title) || "Hello" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= yield :head %>
 
-    <link rel="manifest" href="/manifest.json">
+    <!-- <link rel="manifest" href="/manifest.json"> -->
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
@@ -19,7 +20,7 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="container mx-auto mt-28 px-5">
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,14 @@
 
   <body>
     <main class="container mx-auto mt-28 px-5">
+      <% if flash.notice.present? %>
+        <p class="bg-green-200 p-4 mb-4 rounded-md shadow-sm"><%= flash.notice %></p>
+      <% end %>
+
+      <% if flash.alert.present? %>
+        <p class="bg-red-200 p-4 mb-4 rounded-md shadow-sm"><%= flash.alert %></p>
+      <% end %>
+
       <%= yield %>
     </main>
   </body>

--- a/app/views/turbo_actions/inboxes/_messages.html.erb
+++ b/app/views/turbo_actions/inboxes/_messages.html.erb
@@ -1,0 +1,13 @@
+<%# locals(inbox:, messages:, scope:) %>
+
+<div id="<%= dom_id(inbox, "#{scope}_messages") %>" class="flex flex-wrap">
+  <% messages.each do |message| %>
+    <div class="basis-full border-2 rounded-sm mb-4 p-4">
+      <%= render message %>
+    </div>
+  <% end %>
+
+  <% if messages.none? %>
+    <p class="mt-4 font-light">No <%= scope %> messages</p>
+  <% end %>
+</div>

--- a/app/views/turbo_actions/inboxes/_summary.html.erb
+++ b/app/views/turbo_actions/inboxes/_summary.html.erb
@@ -1,5 +1,9 @@
-<div class="flex flex-wrap">
-  <p class="basis-full text-lg mb-4">
+<%# locals(inbox:) %>
+
+<%= turbo_stream_from(inbox) %>
+
+<div id="<%= dom_id(inbox) %>" class="flex flex-wrap">
+  <p class="font-bold basis-full text-lg mb-4">
     <%= inbox.name %>
   </p>
   <ul class="basis-full mb-2">
@@ -10,5 +14,4 @@
       Total messages: <%= inbox.messages.size %>
     </li>
   </ul>
-  <%= link_to "View", [:turbo_actions, inbox], class: "text-sky-600 hover:underline" %>
 </div>

--- a/app/views/turbo_actions/inboxes/_summary.html.erb
+++ b/app/views/turbo_actions/inboxes/_summary.html.erb
@@ -1,0 +1,14 @@
+<div class="flex flex-wrap">
+  <p class="basis-full text-lg mb-4">
+    <%= inbox.name %>
+  </p>
+  <ul class="basis-full mb-2">
+    <li>
+      Unread messages: <%= inbox.messages.unread.size %>
+    </li>
+    <li>
+      Total messages: <%= inbox.messages.size %>
+    </li>
+  </ul>
+  <%= link_to "View", [:turbo_actions, inbox], class: "text-sky-600 hover:underline" %>
+</div>

--- a/app/views/turbo_actions/inboxes/edit.html.erb
+++ b/app/views/turbo_actions/inboxes/edit.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">TurboActions::Inboxes#edit</h1>
+  <p>Find me in app/views/turbo_actions/inboxes/edit.html.erb</p>
+</div>

--- a/app/views/turbo_actions/inboxes/edit.html.erb
+++ b/app/views/turbo_actions/inboxes/edit.html.erb
@@ -1,4 +1,0 @@
-<div>
-  <h1 class="font-bold text-4xl">TurboActions::Inboxes#edit</h1>
-  <p>Find me in app/views/turbo_actions/inboxes/edit.html.erb</p>
-</div>

--- a/app/views/turbo_actions/inboxes/index.html.erb
+++ b/app/views/turbo_actions/inboxes/index.html.erb
@@ -1,0 +1,9 @@
+<h1 class="font-bold md:text-4xl mb-4">Inboxes (Turbo Actions)</h1>
+
+<div class="flex flex-wrap">
+  <% @inboxes.each do |inbox| %>
+    <div class="basis-full md:basis-1/3 border-2 rounded-sm mr-4 mb-4 p-4">
+      <%= render "summary", inbox: inbox %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/turbo_actions/inboxes/index.html.erb
+++ b/app/views/turbo_actions/inboxes/index.html.erb
@@ -4,6 +4,7 @@
   <% @inboxes.each do |inbox| %>
     <div class="basis-full md:basis-1/3 border-2 rounded-sm mr-4 mb-4 p-4">
       <%= render "summary", inbox: inbox %>
+      <%= link_to "View", [:turbo_actions, inbox], class: "text-sky-600 hover:underline" %>
     </div>
   <% end %>
 </div>

--- a/app/views/turbo_actions/inboxes/index.html.erb
+++ b/app/views/turbo_actions/inboxes/index.html.erb
@@ -1,10 +1,14 @@
+<p class="mb-4">
+  <%= link_to sanitize("&larr; Back to experiments"), :root, class: "text-sky-600 hover:underline" %>
+</p>
+
 <h1 class="font-bold md:text-4xl mb-4">Inboxes (Turbo Actions)</h1>
 
 <div class="flex flex-wrap">
   <% @inboxes.each do |inbox| %>
     <div class="basis-full md:basis-1/3 border-2 rounded-sm mr-4 mb-4 p-4">
       <%= render "summary", inbox: inbox %>
-      <%= link_to "View", [:turbo_actions, inbox], class: "text-sky-600 hover:underline" %>
+      <%= link_to "View", [:turbo_actions, inbox, turbo_enabled: params[:turbo_enabled]], class: "text-sky-600 hover:underline" %>
     </div>
   <% end %>
 </div>

--- a/app/views/turbo_actions/inboxes/show.html.erb
+++ b/app/views/turbo_actions/inboxes/show.html.erb
@@ -8,11 +8,14 @@
   tab_class = "w-24 text-center p-2 rounded-sm mr-2"
   active_tab_class = "#{tab_class} text-white bg-blue-500 hover:bg-blue-400"
   inactive_tab_class = "#{tab_class} bg-slate-200 hover:bg-slate-100"
+  turbo_enabled = params[:turbo_enabled].to_s != "false"
 %>
 
 <div class="flex mt-4">
-  <%= link_to "Unread", [:turbo_actions, @inbox, messages_scope: :unread], class: @messages_scope.eql?(:read) ? inactive_tab_class : active_tab_class %>
-  <%= link_to "Read", [:turbo_actions, @inbox, messages_scope: :read], class: @messages_scope.eql?(:read) ? active_tab_class : inactive_tab_class %>
+  <%= link_to "Unread", [:turbo_actions, @inbox, messages_scope: :unread, turbo_enabled: turbo_enabled], class: @messages_scope.eql?(:read) ? inactive_tab_class : active_tab_class %>
+  <%= link_to "Read", [:turbo_actions, @inbox, messages_scope: :read, turbo_enabled: turbo_enabled], class: @messages_scope.eql?(:read) ? active_tab_class : inactive_tab_class %>
 </div>
 
-<%= render "messages", inbox: @inbox, messages: @messages, scope: @messages_scope %>
+<div data-turbo="<%= turbo_enabled %>">
+  <%= render "messages", inbox: @inbox, messages: @messages, scope: @messages_scope %>
+</div>

--- a/app/views/turbo_actions/inboxes/show.html.erb
+++ b/app/views/turbo_actions/inboxes/show.html.erb
@@ -1,14 +1,18 @@
-
 <p class="mb-4">
   <%= link_to sanitize("&larr; Back to inboxes"), [:turbo_actions, :inboxes], class: "text-sky-600 hover:underline" %>
 </p>
 
 <%= render "summary", inbox: @inbox %>
 
-<div class="flex flex-wrap">
-  <% @inbox.messages.ordered.each do |message| %>
-    <div class="basis-full border-2 rounded-sm mb-4 p-4">
-      <%= render message %>
-    </div>
-  <% end %>
+<%
+  tab_class = "w-24 text-center p-2 rounded-sm mr-2"
+  active_tab_class = "#{tab_class} text-white bg-blue-500 hover:bg-blue-400"
+  inactive_tab_class = "#{tab_class} bg-slate-200 hover:bg-slate-100"
+%>
+
+<div class="flex mt-4">
+  <%= link_to "Unread", [:turbo_actions, @inbox, messages_scope: :unread], class: @messages_scope.eql?(:read) ? inactive_tab_class : active_tab_class %>
+  <%= link_to "Read", [:turbo_actions, @inbox, messages_scope: :read], class: @messages_scope.eql?(:read) ? active_tab_class : inactive_tab_class %>
 </div>
+
+<%= render "messages", inbox: @inbox, messages: @messages, scope: @messages_scope %>

--- a/app/views/turbo_actions/inboxes/show.html.erb
+++ b/app/views/turbo_actions/inboxes/show.html.erb
@@ -1,4 +1,14 @@
-<div>
-  <h1 class="font-bold text-4xl">TurboActions::Inboxes#show</h1>
-  <p>Find me in app/views/turbo_actions/inboxes/show.html.erb</p>
+
+<p class="mb-4">
+  <%= link_to sanitize("&larr; Back to inboxes"), [:turbo_actions, :inboxes], class: "text-sky-600 hover:underline" %>
+</p>
+
+<%= render "summary", inbox: @inbox %>
+
+<div class="flex flex-wrap">
+  <% @inbox.messages.ordered.each do |message| %>
+    <div class="basis-full border-2 rounded-sm mb-4 p-4">
+      <%= render message %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/turbo_actions/inboxes/show.html.erb
+++ b/app/views/turbo_actions/inboxes/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">TurboActions::Inboxes#show</h1>
+  <p>Find me in app/views/turbo_actions/inboxes/show.html.erb</p>
+</div>

--- a/app/views/turbo_actions/inboxes/update.html.erb
+++ b/app/views/turbo_actions/inboxes/update.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">TurboActions::Inboxes#update</h1>
+  <p>Find me in app/views/turbo_actions/inboxes/update.html.erb</p>
+</div>

--- a/app/views/turbo_actions/inboxes/update.html.erb
+++ b/app/views/turbo_actions/inboxes/update.html.erb
@@ -1,4 +1,0 @@
-<div>
-  <h1 class="font-bold text-4xl">TurboActions::Inboxes#update</h1>
-  <p>Find me in app/views/turbo_actions/inboxes/update.html.erb</p>
-</div>

--- a/app/views/turbo_actions/messages/_message.html.erb
+++ b/app/views/turbo_actions/messages/_message.html.erb
@@ -1,0 +1,14 @@
+<%# locals(message:) %>
+
+<% button_class = "bg-blue-500 hover:bg-blue-400 text-white w-full md:w-1/6 p-1 rounded-md shadow-sm" %>
+
+<div id="<%= dom_id(message) %>">
+  <h4 class="font-bold mb-2"><%= message.title %></h4>
+  <p class="font-mono mb-4"><%= message.body %></p>
+
+  <% if message.read_at? %>
+    <%= button_to "Mark as Unread", [:turbo_actions, message], class: button_class, method: :patch, params: { message: { read: false } } %>
+  <% else %>
+    <%= button_to "Mark as Read", [:turbo_actions, message], class: button_class, method: :patch, params: { message: { read: true } } %>
+  <% end %>
+</div>

--- a/app/views/turbo_refreshes/inboxes/_messages.html.erb
+++ b/app/views/turbo_refreshes/inboxes/_messages.html.erb
@@ -1,0 +1,13 @@
+<%# locals(inbox:, messages:, scope:) %>
+
+<div id="<%= dom_id(inbox, "#{scope}_messages") %>" class="flex flex-wrap">
+  <% messages.each do |message| %>
+    <div class="basis-full border-2 rounded-sm mb-4 p-4">
+      <%= render message %>
+    </div>
+  <% end %>
+
+  <% if messages.none? %>
+    <p class="mt-4 font-light">No <%= scope %> messages</p>
+  <% end %>
+</div>

--- a/app/views/turbo_refreshes/inboxes/_summary.html.erb
+++ b/app/views/turbo_refreshes/inboxes/_summary.html.erb
@@ -1,0 +1,17 @@
+<%# locals(inbox:) %>
+
+<%= turbo_stream_from(inbox) %>
+
+<div id="<%= dom_id(inbox) %>" class="flex flex-wrap">
+  <p class="font-bold basis-full text-lg mb-4">
+    <%= inbox.name %>
+  </p>
+  <ul class="basis-full mb-2">
+    <li>
+      Unread messages: <%= inbox.messages.unread.size %>
+    </li>
+    <li>
+      Total messages: <%= inbox.messages.size %>
+    </li>
+  </ul>
+</div>

--- a/app/views/turbo_refreshes/inboxes/index.html.erb
+++ b/app/views/turbo_refreshes/inboxes/index.html.erb
@@ -1,0 +1,10 @@
+<h1 class="font-bold md:text-4xl mb-4">Inboxes (Turbo Refreshes)</h1>
+
+<div class="flex flex-wrap">
+  <% @inboxes.each do |inbox| %>
+    <div class="basis-full md:basis-1/3 border-2 rounded-sm mr-4 mb-4 p-4">
+      <%= render "summary", inbox: inbox %>
+      <%= link_to "View", [:turbo_refreshes, inbox], class: "text-sky-600 hover:underline" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/turbo_refreshes/inboxes/index.html.erb
+++ b/app/views/turbo_refreshes/inboxes/index.html.erb
@@ -1,3 +1,7 @@
+<p class="mb-4">
+  <%= link_to sanitize("&larr; Back to experiments"), :root, class: "text-sky-600 hover:underline" %>
+</p>
+
 <h1 class="font-bold md:text-4xl mb-4">Inboxes (Turbo Refreshes)</h1>
 
 <div class="flex flex-wrap">

--- a/app/views/turbo_refreshes/inboxes/show.html.erb
+++ b/app/views/turbo_refreshes/inboxes/show.html.erb
@@ -1,0 +1,23 @@
+<% content_for :head do %>
+  <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+<% end %>
+
+<p class="mb-4">
+  <%= link_to sanitize("&larr; Back to inboxes"), [:turbo_refreshes, :inboxes], class: "text-sky-600 hover:underline" %>
+</p>
+
+<%= render "summary", inbox: @inbox %>
+
+<%
+  tab_class = "w-24 text-center p-2 rounded-sm mr-2"
+  active_tab_class = "#{tab_class} text-white bg-blue-500 hover:bg-blue-400"
+  inactive_tab_class = "#{tab_class} bg-slate-200 hover:bg-slate-100"
+  turbo_enabled = params[:turbo_enabled].to_s != "false"
+%>
+
+<div class="flex mt-4">
+  <%= link_to "Unread", [:turbo_refreshes, @inbox, messages_scope: :unread], class: @messages_scope.eql?(:read) ? inactive_tab_class : active_tab_class %>
+  <%= link_to "Read", [:turbo_refreshes, @inbox, messages_scope: :read, ], class: @messages_scope.eql?(:read) ? active_tab_class : inactive_tab_class %>
+</div>
+
+<%= render "messages", inbox: @inbox, messages: @messages, scope: @messages_scope %>

--- a/app/views/turbo_refreshes/messages/_message.html.erb
+++ b/app/views/turbo_refreshes/messages/_message.html.erb
@@ -1,0 +1,14 @@
+<%# locals(message:) %>
+
+<% button_class = "bg-blue-500 hover:bg-blue-400 text-white w-full md:w-1/6 p-1 rounded-md shadow-sm" %>
+
+<div id="<%= dom_id(message) %>">
+  <h4 class="font-bold mb-2"><%= message.title %></h4>
+  <p class="font-mono mb-4"><%= message.body %></p>
+
+  <% if message.read_at? %>
+    <%= button_to "Mark as Unread", [:turbo_refreshes, message], class: button_class, method: :patch, params: { message: { read: false } } %>
+  <% else %>
+    <%= button_to "Mark as Read", [:turbo_refreshes, message], class: button_class, method: :patch, params: { message: { read: true } } %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  resources :experiments, only: :index
+
   namespace :turbo_actions do
     resources :inboxes, except: %i[new create destroy]
     resources :messages, only: :update
@@ -19,5 +21,5 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "experiments#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :turbo_actions do
     resources :inboxes, except: %i[new create destroy]
+    resources :messages, only: :update
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :turbo_actions do
+    resources :inboxes, except: %i[new create destroy]
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,14 @@
 Rails.application.routes.draw do
+  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   namespace :turbo_actions do
     resources :inboxes, except: %i[new create destroy]
     resources :messages, only: :update
   end
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  namespace :turbo_refreshes do
+    resources :inboxes, except: %i[new create destroy]
+    resources :messages, only: :update
+  end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,12 @@ Rails.application.routes.draw do
   resources :experiments, only: :index
 
   namespace :turbo_actions do
-    resources :inboxes, except: %i[new create destroy]
+    resources :inboxes, only: %i[index show]
     resources :messages, only: :update
   end
 
   namespace :turbo_refreshes do
-    resources :inboxes, except: %i[new create destroy]
+    resources :inboxes, only: %i[index show]
     resources :messages, only: :update
   end
 

--- a/db/migrate/20240827184221_create_inboxes.rb
+++ b/db/migrate/20240827184221_create_inboxes.rb
@@ -1,0 +1,9 @@
+class CreateInboxes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :inboxes do |t|
+      t.string :name, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240827185324_create_messages.rb
+++ b/db/migrate/20240827185324_create_messages.rb
@@ -1,0 +1,13 @@
+class CreateMessages < ActiveRecord::Migration[7.2]
+  def change
+    create_table :messages do |t|
+      t.references :inbox, foreign_key: true, index: true
+
+      t.string :title
+      t.text :body
+      t.timestamp :read_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,32 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2024_08_27_185324) do
+  create_table "inboxes", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_inboxes_on_name", unique: true
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.integer "inbox_id"
+    t.string "title"
+    t.text "body"
+    t.datetime "read_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["inbox_id"], name: "index_messages_on_inbox_id"
+  end
+
+  add_foreign_key "messages", "inboxes"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+work_inbox = Inbox.create_or_find_by!(name: "Work")
+
+if work_inbox.messages.none?
+  1.upto(5) do |i|
+    work_inbox.messages.create!(title: "Message #{i}", body: "This is the content of message ##{i}")
+  end
+end
+
+personal_inbox = Inbox.create_or_find_by!(name: "Personal")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,11 @@
-work_inbox = Inbox.create_or_find_by!(name: "Work")
+puts "Seeding Inboxes..."
+inboxes = %w[Work Personal].map { |name| Inbox.create_or_find_by!(name: name) }
 
-if work_inbox.messages.none?
-  1.upto(5) do |i|
-    work_inbox.messages.create!(title: "Message #{i}", body: "This is the content of message ##{i}")
-  end
+puts "Seeding Messages..."
+1.upto(50) do |i|
+  title = "Message #{i}"
+  next if Message.where(title: title).exists?
+
+  inbox = inboxes[i % inboxes.size]
+  inbox.messages.create!(title: title, body: "This is the content of message ##{i}")
 end
-
-personal_inbox = Inbox.create_or_find_by!(name: "Personal")

--- a/test/controllers/turbo_actions/inboxes_controller_test.rb
+++ b/test/controllers/turbo_actions/inboxes_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class TurboActions::InboxesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get turbo_actions_inboxes_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get turbo_actions_inboxes_show_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get turbo_actions_inboxes_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get turbo_actions_inboxes_update_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/inboxes.yml
+++ b/test/fixtures/inboxes.yml
@@ -1,0 +1,5 @@
+work:
+  name: Work
+
+personal:
+  name: Personal

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  body: MyString
+  read_at: 2024-08-27 14:53:24
+
+two:
+  title: MyString
+  body: MyString
+  read_at: 2024-08-27 14:53:24

--- a/test/models/inbox_test.rb
+++ b/test/models/inbox_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class InboxTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MessageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
I had been reading about new refreshes and page morphing features in Turbo 8 and I didn't really "get it".  It was something that I needed to poke at and play with myself.  I'm not a Turbo expert, so my basis of understanding of Turbo 7 didn't allow me to see the value of Turbo 8's features.

This PR shows two implementations (or maybe even three!) of essentially the same functionality.  You can checkout this branch locally and start the app by running `overmind s -f Procfile.dev` (or whatever the equivalent `foreman` command is).  You can then navigate to `localhost:<PORT>` and see three experiments listed.

![image](https://github.com/user-attachments/assets/2c705e8e-8663-45dc-9a58-a405a081266a)

You can proceed through those experiments to experience the differences in the behavior of the UI for the three implementations.  You can also review the code to see the trade offs in terms of UX and code complexity.

# Credits

* https://jonsully.net/blog/turbo-8-page-refreshes-morphing-explained-at-length/
* https://dev.37signals.com/a-happier-happy-path-in-turbo-with-morphing/
